### PR TITLE
docs: Add MDN link to 'Bind in Action' for deeper insights

### DIFF
--- a/Publications/Advanced Functional Patterns - Bind in Action.md
+++ b/Publications/Advanced Functional Patterns - Bind in Action.md
@@ -56,4 +56,4 @@ const sayHello = person.sayHello.bind(person);
 setTimeout(sayHello, 1000); // hello John Smith
 ```
 
-Ի դեպ bind մեթոդը JavaScript-ում առկա է դեռևս **ES5** ստանդարտի ժամանակներից և հասկանալի է բոլոր ժամանակակից ցանցային դիտարկիչներին (_նույնիսկ Internet Explorer-ին՝ սկսած 9-րդ տարբերակից_)։
+Ի դեպ _bind_ մեթոդը JavaScript-ում առկա է դեռևս **ES5** ստանդարտի ժամանակներից և հասկանալի է բոլոր ժամանակակից ցանցային դիտարկիչներին (_նույնիսկ Internet Explorer-ին՝ սկսած 9-րդ տարբերակից_)։ _bind_ մեթոդի մասին առավել մանրամասն կարող եք ծանոթանալ [այս հղումով](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind):


### PR DESCRIPTION
Incorporated a link to the MDN documentation on `Function.bind`, providing readers with access to comprehensive details and examples.