### PR TITLE
Add polyfill for Array.from support in older browsers

### DIFF
--- a/Publications/Array.from - Converting Pseudo Arrays and Iterables in JavaScript.md
+++ b/Publications/Array.from - Converting Pseudo Arrays and Iterables in JavaScript.md
@@ -62,4 +62,58 @@ Array.from(object, mapFunction, thisValue)
 - mapFunction-ը հետադարձ կանչի (callback) ֆունկցիա է, որը կանչվում է զանգվածի յուրաքանչյուր էլեմենտի համար (_ինչպես արդեն ասվեց, այս պարամետրը պարտադիր չէ_): Այն իր գործառույթով նման է զանգվածների _map_ մեթոդին, և _Array.from(obj, mapFn, thisArg)_ կանչը համարժեք է _Array.from(obj).map(mapFn, thisArg)_ կանչին, միայն այն տարբերությամբ, որ միջանկյալ զանգված այլևս չի ստեղծվում։
 - thisValue-ն սահմանում է _this_-ի արժեքը՝ _mapFunction_-ի կանչի համար (_նույնպես հանդիսանում է ոչ պարտադիր պարամետր_):
 
-Մեթոդը **ECMAScript** ստանդարտում ներդրվել է _2015_ թվականին (_ES6_) և գործնականում աջակցվում է բոլոր ժամանակակից ցանցային դիտարկիչների կողմից: Խնդիրներ կարող են առաջանալ համեմատաբար հին _Internet Explorer_ դիտարկիչի վրա (_IE վերջին 11-րդ տարբերակը նույնպես այս մեթոդը չի ճանաչում և ապահովության համար կարելի է սքրիփթի մեջ ավելացնել մեթոդի պոլիֆիլը_):
+Մեթոդը **ECMAScript** ստանդարտում ներդրվել է _2015_ թվականին (_ES6_) և գործնականում աջակցվում է բոլոր ժամանակակից ցանցային դիտարկիչների կողմից: Խնդիրներ կարող են առաջանալ համեմատաբար հին _Internet Explorer_ դիտարկիչի վրա (_IE վերջին 11-րդ տարբերակը նույնպես այս մեթոդը չի ճանաչում և ապահովության համար կարելի է սքրիփթի մեջ ավելացնել մեթոդի պոլիֆիլը_): Պոլիֆիլի օրինակ՝
+
+```
+if (!Array.from) {
+  Array.from = (function () {
+    var toStr = Object.prototype.toString;
+    var isCallable = function (fn) {
+      return typeof fn === 'function' || toStr.call(fn) === '[object Function]';
+    };
+    var toInteger = function (value) {
+      var number = Number(value);
+      if (isNaN(number)) { return 0; }
+      if (number === 0 || !isFinite(number)) { return number; }
+      return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+    };
+    var maxSafeInteger = Math.pow(2, 53) - 1;
+    var toLength = function (value) {
+      var len = toInteger(value);
+      return Math.min(Math.max(len, 0), maxSafeInteger);
+    };
+    return function from(arrayLike /*, mapFn, thisArg */) {
+      var C = this;
+      var items = Object(arrayLike);
+      if (arrayLike == null) {
+        throw new TypeError('Array.from requires an array-like object - not null or undefined');
+      }
+      var mapFn = arguments.length > 1 ? arguments[1] : void undefined;
+      var T;
+      if (typeof mapFn !== 'undefined') {
+        if (!isCallable(mapFn)) {
+          throw new TypeError('Array.from: when provided, the second argument must be a function');
+        }
+        if (arguments.length > 2) {
+          T = arguments[2];
+        }
+      }
+      var len = toLength(items.length);
+      var A = isCallable(C) ? Object(new C(len)) : new Array(len);
+      var k = 0;
+      var kValue;
+      while (k < len) {
+        kValue = items[k];
+        if (mapFn) {
+          A[k] = typeof T === 'undefined' ? mapFn(kValue, k) : mapFn.call(T, kValue, k);
+        } else {
+          A[k] = kValue;
+        }
+        k += 1;
+      }
+      A.length = len;
+      return A;
+    };
+  }());
+}
+```


### PR DESCRIPTION
Introduced a polyfill for `Array.from` to ensure compatibility with legacy browsers, enhancing the 'Array.from - Converting Pseudo Arrays and Iterables in JavaScript' publication with broader support.