### PR TITLE
docs: Add MDN link for `hasOwnProperty` method details

### DIFF
--- a/Publications/Best Practices for Property Checking in JavaScript.md
+++ b/Publications/Best Practices for Property Checking in JavaScript.md
@@ -107,4 +107,4 @@ alert (car.hasOwnProperty("speed")); // true
 alert (car.hasOwnProperty("toString")); // false
 ```
 
-Ինչպես տեսնում ենք **_hasOwnProperty_** մեթոդը բոլորովին հաշվի չի առնում պրոտոտիպերի շղթայից ժառանգված հատկություններն ու մեթոդները։ Այս եղանակներից ո՞րն օգտագործել, կախված է խնդրի բնույթից, բայց մեծամասամբ ավելի անվտանգ է **_hasOwnProperty_** մեթոդը։
+Ինչպես տեսնում ենք **_hasOwnProperty_** մեթոդը բոլորովին հաշվի չի առնում պրոտոտիպերի շղթայից ժառանգված հատկություններն ու մեթոդները։ Այս եղանակներից ո՞րն օգտագործել, կախված է խնդրի բնույթից, բայց մեծամասամբ ավելի անվտանգ է **_hasOwnProperty_** մեթոդը։ **_hasOwnProperty_** մեթոդի մասին ավելի մանրամասն կարող եք ծանոթանալ [այս հղումով](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty)։


### PR DESCRIPTION
Enhanced the 'Best Practices for Property Checking in JavaScript' section by linking to the MDN documentation on `hasOwnProperty`, providing readers with a resource for deeper understanding.